### PR TITLE
Update CI Action for recuring runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  schedule:
+    - cron: '0 8 4,19 * *' #At 8:00AM every 4th and 19th of the month 
   push:
     branches:
     - master


### PR DESCRIPTION
See #160 
Added a recurring update of the projects page stats using the already existing Github Action, which worked well.

I kept the update-when-push, because I feel like it it still relevant and we won't push that much.
