### PR TITLE
fix typo dans l'extension de la photo AmineFanid.jpg

### DIFF
--- a/data/equipe.yml
+++ b/data/equipe.yml
@@ -129,7 +129,7 @@ membres:
         url: "https://github.com/AmineFanid"
       - title: linkedin
         url: "https://www.linkedin.com/in/amine-fanid-7936a12b0/"
-    image: "images/membres/AmineFanid.png"
+    image: "images/membres/AmineFanid.jpg"
 
 anciensmembres:
   - name: "Roch D'amour"


### PR DESCRIPTION
À cause d'un copy/paste, j'ai mis .png au lieu de .jpg dans l'extension de ma photo... Ça devrait être fixed maintenant